### PR TITLE
Set client_max_body_size to 53Mb

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Fab-manager is the Fab Lab management solution. It provides a comprehensive, web-based, open-source tool to simplify your administrative tasks, and document your marker's projects.
 
 
-**Shipped version:** 5.4.20~ynh1 *(:warning: This is the `testing` branch. The [`master` branch](https://github.com/YunoHost-Apps/fab-manager_ynh/tree/master) used in the catalog is currently on version 5.4.19\~ynh1.)*
-
+**Shipped version:** 5.4.20~ynh1
 
 **Demo:** https://www.fab-manager.com/fr/demo
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -18,8 +18,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 Fab-manager is the Fab Lab management solution. It provides a comprehensive, web-based, open-source tool to simplify your administrative tasks, and document your marker's projects.
 
 
-**Version incluse :** 5.4.20~ynh1 *(:warning: Il s'agit de la branche `testing`. La [branche `master`](https://github.com/YunoHost-Apps/fab-manager_ynh/tree/master) utilisée dans le catalogue est actuellement en 5.4.19\~ynh1.)*
-
+**Version incluse :** 5.4.20~ynh1
 
 **Démo :** https://www.fab-manager.com/fr/demo
 

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -5,7 +5,7 @@ location __PATH__/ {
   alias __FINALPATH__/;
 
   # Common parameter to increase upload size limit in conjunction with dedicated php-fpm file
-  #client_max_body_size 50M;
+  client_max_body_size 53M;
 
   try_files $uri/index.html $uri @puma;
 


### PR DESCRIPTION
Update the `client_max_body_size` as we need to authorize users to uploads files likes Pictures, CAO files, 3D modèles, etc. Set as the default `max_import_size` variable from the [Rails App secrets config](https://github.com/YunoHost-Apps/fab-manager_ynh/blob/master/conf/secrets.yml#L38).

## Problem

- Nginx send a 413 error when a user try to upload a file bigger than 1Mb.

## Solution

- set `client_max_body_size` to 53Mb

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (I have edited the /etc/nginx/conf.d/domain.ltd.d/fab-manager.conf to test it, and it's working)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
