### PR TITLE
Confirm admin email to avoid being locked out with wrong unverified email

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -83,6 +83,8 @@ fabmanager_seed_db() {
         env_ruby bash -c "set -a; source '$install_dir/.env'; set +a ; RAILS_ENV=production ADMIN_EMAIL='$admin_mail' ADMIN_PASSWORD='$password' bin/bundle exec rails db:schema:load"
         ynh_psql_execute_as_root --database="$db_name" --sql="ALTER USER $db_user WITH NOSUPERUSER;"
         env_ruby bash -c "set -a; source '$install_dir/.env'; set +a ; RAILS_ENV=production ADMIN_EMAIL='$admin_mail' ADMIN_PASSWORD='$password' bin/bundle exec rails db:seed"
+        # Create the first admin user with confirmed email
+        env_ruby bash -c "set -a; source '$install_dir/.env'; set +a ; RAILS_ENV=production ADMIN_EMAIL='$admin_mail' ADMIN_PASSWORD='$password bin/tootctl accounts modify "$admin" --email="$admin_mail" --confirmed --role=Owner'
     popd
 }
 


### PR DESCRIPTION
## Problem

#133 

## Solution

- Confirm admin email at install to avoid being locked out with wrong unverified email
- after seeding db, `tootctl user modify --confirmed` etc...

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
