### PR TITLE
Upgrade to v6.3.46

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -1,6 +1,8 @@
 # All available README files by language
 
 - [Read the README in English](README.md)
+- [Llegir el README en català](README_ca.md)
+- [Die README in Deutsch lesen](README_de.md)
 - [Lea el README en español](README_es.md)
 - [Irakurri README euskaraz](README_eu.md)
 - [Lire le README en français](README_fr.md)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It shall NOT be edited by hand.
 Fab-manager is the Fab Lab management solution. It provides a comprehensive, web-based, open-source tool to simplify your administrative tasks, and document your marker's projects.
 
 
-**Shipped version:** 6.3.44~ynh1
+**Shipped version:** 6.3.46~ynh1
 
 **Demo:** <https://www.fab-manager.com/fr/demo>
 

--- a/README_ca.md
+++ b/README_ca.md
@@ -1,0 +1,52 @@
+<!--
+N.B.: Aquest README ha estat generat automàticament per <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+NO s'ha de modificar manualment.
+-->
+
+# Fab-manager per YunoHost
+
+[![Nivell d'integració](https://apps.yunohost.org/badge/integration/fab-manager)](https://ci-apps.yunohost.org/ci/apps/fab-manager/)
+![Estat de funcionament](https://apps.yunohost.org/badge/state/fab-manager)
+![Estat de manteniment](https://apps.yunohost.org/badge/maintained/fab-manager)
+
+[![Instal·la Fab-manager amb YunoHosth](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=fab-manager)
+
+*[Llegeix aquest README en altres idiomes.](./ALL_README.md)*
+
+> *Aquest paquet et permet instal·lar Fab-manager de forma ràpida i senzilla en un servidor YunoHost.*  
+> *Si no tens YunoHost, consulta [la guia](https://yunohost.org/install) per saber com instal·lar-lo.*
+
+## Visió general
+
+Fab-manager is the Fab Lab management solution. It provides a comprehensive, web-based, open-source tool to simplify your administrative tasks, and document your marker's projects.
+
+
+**Versió inclosa:** 6.3.46~ynh1
+
+**Demo:** <https://www.fab-manager.com/fr/demo>
+
+## Captures de pantalla
+
+![Captures de pantalla de Fab-manager](./doc/screenshots/dashboard-mockup.webp)
+
+## Documentació i recursos
+
+- Lloc web oficial de l'aplicació: <https://www.fab-manager.com>
+- Documentació oficial per l'administrador: <http://doc.fab.mn>
+- Repositori oficial del codi de l'aplicació: <https://github.com/sleede/fab-manager>
+- Botiga YunoHost: <https://apps.yunohost.org/app/fab-manager>
+- Reportar un error: <https://github.com/YunoHost-Apps/fab-manager_ynh/issues>
+
+## Informació per a desenvolupadors
+
+Envieu les pull request a la [branca `testing`](https://github.com/YunoHost-Apps/fab-manager_ynh/tree/testing).
+
+Per provar la branca `testing`, procedir com descrit a continuació:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/fab-manager_ynh/tree/testing --debug
+o
+sudo yunohost app upgrade fab-manager -u https://github.com/YunoHost-Apps/fab-manager_ynh/tree/testing --debug
+```
+
+**Més informació sobre l'empaquetatge d'aplicacions:** <https://yunohost.org/packaging_apps>

--- a/README_de.md
+++ b/README_de.md
@@ -1,0 +1,52 @@
+<!--
+N.B.: Diese README wurde automatisch von <https://github.com/YunoHost/apps/tree/master/tools/readme_generator> generiert.
+Sie darf NICHT von Hand bearbeitet werden.
+-->
+
+# Fab-manager für YunoHost
+
+[![Integrations-Level](https://apps.yunohost.org/badge/integration/fab-manager)](https://ci-apps.yunohost.org/ci/apps/fab-manager/)
+![Funktionsstatus](https://apps.yunohost.org/badge/state/fab-manager)
+![Wartungsstatus](https://apps.yunohost.org/badge/maintained/fab-manager)
+
+[![Fab-manager mit YunoHost installieren](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=fab-manager)
+
+*[Dieses README in anderen Sprachen lesen.](./ALL_README.md)*
+
+> *Mit diesem Paket können Sie Fab-manager schnell und einfach auf einem YunoHost-Server installieren.*  
+> *Wenn Sie YunoHost nicht haben, lesen Sie bitte [die Anleitung](https://yunohost.org/install), um zu erfahren, wie Sie es installieren.*
+
+## Übersicht
+
+Fab-manager is the Fab Lab management solution. It provides a comprehensive, web-based, open-source tool to simplify your administrative tasks, and document your marker's projects.
+
+
+**Ausgelieferte Version:** 6.3.46~ynh1
+
+**Demo:** <https://www.fab-manager.com/fr/demo>
+
+## Bildschirmfotos
+
+![Bildschirmfotos von Fab-manager](./doc/screenshots/dashboard-mockup.webp)
+
+## Dokumentation und Ressourcen
+
+- Offizielle Website der App: <https://www.fab-manager.com>
+- Offizielle Verwaltungsdokumentation: <http://doc.fab.mn>
+- Upstream App Repository: <https://github.com/sleede/fab-manager>
+- YunoHost-Shop: <https://apps.yunohost.org/app/fab-manager>
+- Einen Fehler melden: <https://github.com/YunoHost-Apps/fab-manager_ynh/issues>
+
+## Entwicklerinformationen
+
+Bitte senden Sie Ihren Pull-Request an den [`testing` branch](https://github.com/YunoHost-Apps/fab-manager_ynh/tree/testing).
+
+Um den `testing` Branch auszuprobieren, gehen Sie bitte wie folgt vor:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/fab-manager_ynh/tree/testing --debug
+oder
+sudo yunohost app upgrade fab-manager -u https://github.com/YunoHost-Apps/fab-manager_ynh/tree/testing --debug
+```
+
+**Weitere Informationen zur App-Paketierung:** <https://yunohost.org/packaging_apps>

--- a/README_es.md
+++ b/README_es.md
@@ -3,7 +3,7 @@ Este archivo README esta generado automaticamente<https://github.com/YunoHost/ap
 No se debe editar a mano.
 -->
 
-# Fab-manager para Yunohost
+# Fab-manager para YunoHost
 
 [![Nivel de integración](https://apps.yunohost.org/badge/integration/fab-manager)](https://ci-apps.yunohost.org/ci/apps/fab-manager/)
 ![Estado funcional](https://apps.yunohost.org/badge/state/fab-manager)
@@ -21,7 +21,7 @@ No se debe editar a mano.
 Fab-manager is the Fab Lab management solution. It provides a comprehensive, web-based, open-source tool to simplify your administrative tasks, and document your marker's projects.
 
 
-**Versión actual:** 6.3.44~ynh1
+**Versión actual:** 6.3.46~ynh1
 
 **Demo:** <https://www.fab-manager.com/fr/demo>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -21,7 +21,7 @@ EZ editatu eskuz.
 Fab-manager is the Fab Lab management solution. It provides a comprehensive, web-based, open-source tool to simplify your administrative tasks, and document your marker's projects.
 
 
-**Paketatutako bertsioa:** 6.3.44~ynh1
+**Paketatutako bertsioa:** 6.3.46~ynh1
 
 **Demoa:** <https://www.fab-manager.com/fr/demo>
 
@@ -41,7 +41,7 @@ Fab-manager is the Fab Lab management solution. It provides a comprehensive, web
 
 Bidali `pull request`a [`testing` abarrera](https://github.com/YunoHost-Apps/fab-manager_ynh/tree/testing).
 
-`testing` abarra probatzeko, ondorengoa egin:
+`testing` abarra probatzeko, honakoa egin:
 
 ```bash
 sudo yunohost app install https://github.com/YunoHost-Apps/fab-manager_ynh/tree/testing --debug

--- a/README_fr.md
+++ b/README_fr.md
@@ -21,7 +21,7 @@ Il NE doit PAS être modifié à la main.
 Fab-manager is the Fab Lab management solution. It provides a comprehensive, web-based, open-source tool to simplify your administrative tasks, and document your marker's projects.
 
 
-**Version incluse :** 6.3.44~ynh1
+**Version incluse :** 6.3.46~ynh1
 
 **Démo :** <https://www.fab-manager.com/fr/demo>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ NON debe editarse manualmente.
 Fab-manager is the Fab Lab management solution. It provides a comprehensive, web-based, open-source tool to simplify your administrative tasks, and document your marker's projects.
 
 
-**Versión proporcionada:** 6.3.44~ynh1
+**Versión proporcionada:** 6.3.46~ynh1
 
 **Demo:** <https://www.fab-manager.com/fr/demo>
 

--- a/README_id.md
+++ b/README_id.md
@@ -21,7 +21,7 @@ Ini TIDAK boleh diedit dengan tangan.
 Fab-manager is the Fab Lab management solution. It provides a comprehensive, web-based, open-source tool to simplify your administrative tasks, and document your marker's projects.
 
 
-**Versi terkirim:** 6.3.44~ynh1
+**Versi terkirim:** 6.3.46~ynh1
 
 **Demo:** <https://www.fab-manager.com/fr/demo>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -21,7 +21,7 @@ Hij mag NIET handmatig aangepast worden.
 Fab-manager is the Fab Lab management solution. It provides a comprehensive, web-based, open-source tool to simplify your administrative tasks, and document your marker's projects.
 
 
-**Geleverde versie:** 6.3.44~ynh1
+**Geleverde versie:** 6.3.46~ynh1
 
 **Demo:** <https://www.fab-manager.com/fr/demo>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -21,7 +21,7 @@ Nie powinno być ono edytowane ręcznie.
 Fab-manager is the Fab Lab management solution. It provides a comprehensive, web-based, open-source tool to simplify your administrative tasks, and document your marker's projects.
 
 
-**Dostarczona wersja:** 6.3.44~ynh1
+**Dostarczona wersja:** 6.3.46~ynh1
 
 **Demo:** <https://www.fab-manager.com/fr/demo>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,7 +21,7 @@
 Fab-manager is the Fab Lab management solution. It provides a comprehensive, web-based, open-source tool to simplify your administrative tasks, and document your marker's projects.
 
 
-**Поставляемая версия:** 6.3.44~ynh1
+**Поставляемая версия:** 6.3.46~ynh1
 
 **Демо-версия:** <https://www.fab-manager.com/fr/demo>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -21,7 +21,7 @@
 Fab-manager is the Fab Lab management solution. It provides a comprehensive, web-based, open-source tool to simplify your administrative tasks, and document your marker's projects.
 
 
-**分发版本：** 6.3.44~ynh1
+**分发版本：** 6.3.46~ynh1
 
 **演示：** <https://www.fab-manager.com/fr/demo>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Fab-manager"
 description.en = "Fab Lab management solution"
 description.fr = "Solution de gestion de Fab Lab"
 
-version = "6.3.44~ynh1"
+version = "6.3.46~ynh1"
 
 maintainers = []
 
@@ -48,8 +48,8 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    url = "https://github.com/sleede/fab-manager/archive/refs/tags/v6.3.44.tar.gz"
-    sha256 = "8648d5e8f3ac28c5127c286a7f7e2b2fea53161af87ffa92bbe000a1ddde464a"
+    url = "https://github.com/sleede/fab-manager/archive/refs/tags/v6.3.46.tar.gz"
+    sha256 = "9918aa47881a34f0242ab6d2ea70bfeb68575557b06f26e4724dad85be2766f2"
 
     autoupdate.strategy = "latest_github_tag"
 


### PR DESCRIPTION
Upgrade sources
- `main` v6.3.46: https://github.com/sleede/fab-manager/releases/tag/6.3.46

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
